### PR TITLE
fix(security): resolve critical issues C-2 through C-5 plus bonus fixes

### DIFF
--- a/lib/__tests__/helpers/users/jwt.test.ts
+++ b/lib/__tests__/helpers/users/jwt.test.ts
@@ -39,13 +39,14 @@ describe("JWT Helpers", () => {
 
       createJWT(user);
 
-      expect(jwt.sign).toHaveBeenCalledWith(
-        {
-          id: user.id,
-          name: user.name,
-        },
-        "test-secret-key",
-      );
+ expect(jwt.sign).toHaveBeenCalledWith(
+ {
+ id: user.id,
+ name: user.name,
+ },
+ "test-secret-key",
+ { expiresIn: "24h", algorithm: "HS256" }
+ );
     });
   });
 
@@ -73,8 +74,9 @@ describe("JWT Helpers", () => {
       (jwt.verify as ReturnType<typeof vi.fn>).mockReturnValue({ id: "user123" } as jwt.JwtPayload);
 
       verifyJWT("some_token");
-
-      expect(jwt.verify).toHaveBeenCalledWith("some_token", "test-secret-key");
-    });
+ expect(jwt.verify).toHaveBeenCalledWith("some_token", "test-secret-key", {
+ algorithms: ["HS256"],
+ });
   });
+ });
 });

--- a/lib/__tests__/helpers/users/jwt.test.ts
+++ b/lib/__tests__/helpers/users/jwt.test.ts
@@ -1,82 +1,82 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { createJWT, verifyJWT } from "../../../helpers/users/jwt";
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createJWT, verifyJWT } from '../../../helpers/users/jwt';
 
 // Mock jwt library
-vi.mock("jsonwebtoken", () => ({
+vi.mock('jsonwebtoken', () => ({
   default: {
-    sign: vi.fn(() => "mocked_token"),
+    sign: vi.fn(() => 'mocked_token'),
     verify: vi.fn(),
   },
 }));
 
 // Mock logger
-vi.mock("tslog", () => ({
+vi.mock('tslog', () => ({
   Logger: class {
     error = vi.fn();
   },
 }));
 
-import jwt from "jsonwebtoken";
+import jwt from 'jsonwebtoken';
 
 const originalEnv = process.env;
 
-describe("JWT Helpers", () => {
+describe('JWT Helpers', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env = { ...originalEnv, JWT_KEY: "test-secret-key" };
+    process.env = { ...originalEnv, JWT_KEY: 'test-secret-key' };
   });
 
-  describe("createJWT", () => {
-    it("should create a JWT token with user id and name", () => {
-      const user = { id: "user123", name: "John Doe" };
+  describe('createJWT', () => {
+    it('should create a JWT token with user id and name', () => {
+      const user = { id: 'user123', name: 'John Doe' };
       const token = createJWT(user);
 
-      expect(token).toBe("mocked_token");
+      expect(token).toBe('mocked_token');
     });
 
-    it("should call jwt.sign with correct payload", () => {
-      const user = { id: "user123", name: "John Doe" };
+    it('should call jwt.sign with correct payload', () => {
+      const user = { id: 'user123', name: 'John Doe' };
 
       createJWT(user);
 
- expect(jwt.sign).toHaveBeenCalledWith(
- {
- id: user.id,
- name: user.name,
- },
- "test-secret-key",
- { expiresIn: "24h", algorithm: "HS256" }
- );
+      expect(jwt.sign).toHaveBeenCalledWith(
+        {
+          id: user.id,
+          name: user.name,
+        },
+        'test-secret-key',
+        { expiresIn: '24h', algorithm: 'HS256' }
+      );
     });
   });
 
-  describe("verifyJWT", () => {
-    it("should return user payload when token is valid", () => {
-      const mockPayload = { id: "user123", name: "John Doe" };
+  describe('verifyJWT', () => {
+    it('should return user payload when token is valid', () => {
+      const mockPayload = { id: 'user123', name: 'John Doe' };
       (jwt.verify as ReturnType<typeof vi.fn>).mockReturnValue(mockPayload as jwt.JwtPayload);
 
-      const result = verifyJWT("valid_token");
+      const result = verifyJWT('valid_token');
 
       expect(result).toEqual(mockPayload);
     });
 
-    it("should return null when token is invalid", () => {
+    it('should return null when token is invalid', () => {
       (jwt.verify as ReturnType<typeof vi.fn>).mockImplementation(() => {
-        throw new Error("Invalid token");
+        throw new Error('Invalid token');
       });
 
-      const result = verifyJWT("invalid_token");
+      const result = verifyJWT('invalid_token');
 
       expect(result).toBeNull();
     });
 
-    it("should call jwt.verify with token and secret", () => {
-      (jwt.verify as ReturnType<typeof vi.fn>).mockReturnValue({ id: "user123" } as jwt.JwtPayload);
+    it('should call jwt.verify with token and secret', () => {
+      (jwt.verify as ReturnType<typeof vi.fn>).mockReturnValue({ id: 'user123' } as jwt.JwtPayload);
 
-      verifyJWT("some_token");
- expect(jwt.verify).toHaveBeenCalledWith("some_token", "test-secret-key", {
- algorithms: ["HS256"],
- });
+      verifyJWT('some_token');
+      expect(jwt.verify).toHaveBeenCalledWith('some_token', 'test-secret-key', {
+        algorithms: ['HS256'],
+      });
+    });
   });
- });
 });

--- a/lib/helpers/users/jwt.ts
+++ b/lib/helpers/users/jwt.ts
@@ -5,20 +5,23 @@ import { Logger } from "tslog";
 const log = new Logger();
 
 export const createJWT = (user: { id: string; name: string }) => {
-  return jwt.sign(
-    {
-      id: user.id,
-      name: user.name,
-    },
-    process.env.JWT_KEY!
-  );
+ return jwt.sign(
+ {
+ id: user.id,
+ name: user.name,
+ },
+ process.env.JWT_KEY!,
+ { expiresIn: "24h", algorithm: "HS256" }
+ );
 };
 
 export const verifyJWT = (token: string): UserPayload | null => {
-  try {
-    return jwt.verify(token, process.env.JWT_KEY!) as UserPayload;
-  } catch (err) {
-    log.error(err);
-    return null;
-  }
+ try {
+ return jwt.verify(token, process.env.JWT_KEY!, {
+ algorithms: ["HS256"],
+ }) as UserPayload;
+ } catch (err) {
+ log.error(err);
+ return null;
+ }
 };

--- a/lib/helpers/users/jwt.ts
+++ b/lib/helpers/users/jwt.ts
@@ -1,27 +1,27 @@
-import { UserPayload } from "@/types/user";
-import jwt from "jsonwebtoken";
-import { Logger } from "tslog";
+import { UserPayload } from '@/types/user';
+import jwt from 'jsonwebtoken';
+import { Logger } from 'tslog';
 
 const log = new Logger();
 
 export const createJWT = (user: { id: string; name: string }) => {
- return jwt.sign(
- {
- id: user.id,
- name: user.name,
- },
- process.env.JWT_KEY!,
- { expiresIn: "24h", algorithm: "HS256" }
- );
+  return jwt.sign(
+    {
+      id: user.id,
+      name: user.name,
+    },
+    process.env.JWT_KEY!,
+    { expiresIn: '24h', algorithm: 'HS256' }
+  );
 };
 
 export const verifyJWT = (token: string): UserPayload | null => {
- try {
- return jwt.verify(token, process.env.JWT_KEY!, {
- algorithms: ["HS256"],
- }) as UserPayload;
- } catch (err) {
- log.error(err);
- return null;
- }
+  try {
+    return jwt.verify(token, process.env.JWT_KEY!, {
+      algorithms: ['HS256'],
+    }) as UserPayload;
+  } catch (err) {
+    log.error(err);
+    return null;
+  }
 };

--- a/src/app/[locale]/profile/page.tsx
+++ b/src/app/[locale]/profile/page.tsx
@@ -17,7 +17,7 @@ export default function Promises() {
 
   const { doRequest } = useRequest({
     url: "/api/users/delete-user",
-    method: "get",
+    method: "delete",
     onSuccess: () => {
       updateCurrentUser();
       router.push(`/${locale}`);

--- a/src/app/api/parties/campaigns/route.ts
+++ b/src/app/api/parties/campaigns/route.ts
@@ -3,78 +3,74 @@ import { fetchAllCampaigns } from "@/lib/database/parties/campaigns/getAllCampag
 import { fetchCampaign } from "@/lib/database/parties/campaigns/getCampaign";
 import { saveCampaign } from "@/lib/database/parties/campaigns/saveCampaign";
 import { NextRequest, NextResponse } from "next/server";
+import { isAuthorized } from "@/src/middleware/isAuthorized";
 import { Logger } from "tslog";
 
 const log = new Logger();
 
 export async function GET(request: NextRequest) {
-  try {
-    const { searchParams } = new URL(request.url);
-    const party_id = Number(searchParams.get("party_id"));
+ try {
+ const { searchParams } = new URL(request.url);
+ const party_id = Number(searchParams.get("party_id"));
 
-    if (party_id && !isNaN(party_id)) {
-      const { campaignsOfParty } = await fetchCampaign(party_id);
-      return NextResponse.json(campaignsOfParty);
-    } else {
-      const { campaigns } = await fetchAllCampaigns();
-      return NextResponse.json(campaigns);
-    }
-  } catch (error) {
-    log.error("Error encoding data:", error);
-    return NextResponse.json(
-      {
-        success: false,
-        message: "Getting Parties data failed",
-        error: String(error),
-      },
-      { status: 200 }
-    );
-  }
+ if (party_id && !isNaN(party_id)) {
+ const { campaignsOfParty } = await fetchCampaign(party_id);
+ return NextResponse.json(campaignsOfParty);
+ } else {
+ const { campaigns } = await fetchAllCampaigns();
+ return NextResponse.json(campaigns);
+ }
+ } catch (error) {
+ log.error("Error fetching campaigns:", error);
+ return NextResponse.json(
+ { success: false, message: "Getting Campaign data failed" },
+ { status: 500 }
+ );
+ }
 }
 
 export async function POST(req: NextRequest) {
-  const { year, party_id, campaign_pdf_url } = await req.json();
+ if (!(await isAuthorized(req))) {
+ return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+ }
 
-  if (!year || !party_id || !campaign_pdf_url) {
-    return NextResponse.json({ error: "Bad Request" }, { status: 400 });
-  }
+ const { year, party_id, campaign_pdf_url } = await req.json();
 
-  try {
-    const { id } = await saveCampaign(year, party_id, campaign_pdf_url);
-    return NextResponse.json({ id }, { status: 201 });
-  } catch (error) {
-    log.error("Error encoding data:", error);
-    return NextResponse.json(
-      {
-        success: false,
-        message: "Saving Campaign data failed",
-        error: error,
-      },
-      { status: 200 }
-    );
-  }
+ if (!year || !party_id || !campaign_pdf_url) {
+ return NextResponse.json({ error: "Bad Request" }, { status: 400 });
+ }
+
+ try {
+ const { id } = await saveCampaign(year, party_id, campaign_pdf_url);
+ return NextResponse.json({ id }, { status: 201 });
+ } catch (error) {
+ log.error("Error saving campaign:", error);
+ return NextResponse.json(
+ { success: false, message: "Saving Campaign data failed" },
+ { status: 500 }
+ );
+ }
 }
 
 export async function DELETE(req: NextRequest) {
-  const { campaign_id } = await req.json();
+ if (!(await isAuthorized(req))) {
+ return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+ }
 
-  if (!campaign_id) {
-    return NextResponse.json({ error: "Bad Request" }, { status: 400 });
-  }
+ const { campaign_id } = await req.json();
 
-  try {
-    const { id } = await deleteCampaign(campaign_id);
+ if (!campaign_id) {
+ return NextResponse.json({ error: "Bad Request" }, { status: 400 });
+ }
 
-    return NextResponse.json({ id }, { status: 201 });
-  } catch (error) {
-    log.error("Error encoding data:", error);
-    return NextResponse.json(
-      {
-        success: false,
-        message: "Saving Parties data failed",
-        error: String(error),
-      },
-      { status: 200 }
-    );
-  }
+ try {
+ const { id } = await deleteCampaign(campaign_id);
+ return NextResponse.json({ id }, { status: 200 });
+ } catch (error) {
+ log.error("Error deleting campaign:", error);
+ return NextResponse.json(
+ { success: false, message: "Deleting Campaign data failed" },
+ { status: 500 }
+ );
+ }
 }

--- a/src/app/api/parties/campaigns/route.ts
+++ b/src/app/api/parties/campaigns/route.ts
@@ -1,76 +1,76 @@
-import { deleteCampaign } from "@/lib/database/parties/campaigns/deleteCampaign";
-import { fetchAllCampaigns } from "@/lib/database/parties/campaigns/getAllCampagns";
-import { fetchCampaign } from "@/lib/database/parties/campaigns/getCampaign";
-import { saveCampaign } from "@/lib/database/parties/campaigns/saveCampaign";
-import { NextRequest, NextResponse } from "next/server";
-import { isAuthorized } from "@/src/middleware/isAuthorized";
-import { Logger } from "tslog";
+import { deleteCampaign } from '@/lib/database/parties/campaigns/deleteCampaign';
+import { fetchAllCampaigns } from '@/lib/database/parties/campaigns/getAllCampagns';
+import { fetchCampaign } from '@/lib/database/parties/campaigns/getCampaign';
+import { saveCampaign } from '@/lib/database/parties/campaigns/saveCampaign';
+import { NextRequest, NextResponse } from 'next/server';
+import { isAuthorized } from '@/src/middleware/isAuthorized';
+import { Logger } from 'tslog';
 
 const log = new Logger();
 
 export async function GET(request: NextRequest) {
- try {
- const { searchParams } = new URL(request.url);
- const party_id = Number(searchParams.get("party_id"));
+  try {
+    const { searchParams } = new URL(request.url);
+    const party_id = Number(searchParams.get('party_id'));
 
- if (party_id && !isNaN(party_id)) {
- const { campaignsOfParty } = await fetchCampaign(party_id);
- return NextResponse.json(campaignsOfParty);
- } else {
- const { campaigns } = await fetchAllCampaigns();
- return NextResponse.json(campaigns);
- }
- } catch (error) {
- log.error("Error fetching campaigns:", error);
- return NextResponse.json(
- { success: false, message: "Getting Campaign data failed" },
- { status: 500 }
- );
- }
+    if (party_id && !isNaN(party_id)) {
+      const { campaignsOfParty } = await fetchCampaign(party_id);
+      return NextResponse.json(campaignsOfParty);
+    } else {
+      const { campaigns } = await fetchAllCampaigns();
+      return NextResponse.json(campaigns);
+    }
+  } catch (error) {
+    log.error('Error fetching campaigns:', error);
+    return NextResponse.json(
+      { success: false, message: 'Getting Campaign data failed' },
+      { status: 500 }
+    );
+  }
 }
 
 export async function POST(req: NextRequest) {
- if (!(await isAuthorized(req))) {
- return NextResponse.json({ error: "Forbidden" }, { status: 403 });
- }
+  if (!(await isAuthorized(req))) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
 
- const { year, party_id, campaign_pdf_url } = await req.json();
+  const { year, party_id, campaign_pdf_url } = await req.json();
 
- if (!year || !party_id || !campaign_pdf_url) {
- return NextResponse.json({ error: "Bad Request" }, { status: 400 });
- }
+  if (!year || !party_id || !campaign_pdf_url) {
+    return NextResponse.json({ error: 'Bad Request' }, { status: 400 });
+  }
 
- try {
- const { id } = await saveCampaign(year, party_id, campaign_pdf_url);
- return NextResponse.json({ id }, { status: 201 });
- } catch (error) {
- log.error("Error saving campaign:", error);
- return NextResponse.json(
- { success: false, message: "Saving Campaign data failed" },
- { status: 500 }
- );
- }
+  try {
+    const { id } = await saveCampaign(year, party_id, campaign_pdf_url);
+    return NextResponse.json({ id }, { status: 201 });
+  } catch (error) {
+    log.error('Error saving campaign:', error);
+    return NextResponse.json(
+      { success: false, message: 'Saving Campaign data failed' },
+      { status: 500 }
+    );
+  }
 }
 
 export async function DELETE(req: NextRequest) {
- if (!(await isAuthorized(req))) {
- return NextResponse.json({ error: "Forbidden" }, { status: 403 });
- }
+  if (!(await isAuthorized(req))) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
 
- const { campaign_id } = await req.json();
+  const { campaign_id } = await req.json();
 
- if (!campaign_id) {
- return NextResponse.json({ error: "Bad Request" }, { status: 400 });
- }
+  if (!campaign_id) {
+    return NextResponse.json({ error: 'Bad Request' }, { status: 400 });
+  }
 
- try {
- const { id } = await deleteCampaign(campaign_id);
- return NextResponse.json({ id }, { status: 200 });
- } catch (error) {
- log.error("Error deleting campaign:", error);
- return NextResponse.json(
- { success: false, message: "Deleting Campaign data failed" },
- { status: 500 }
- );
- }
+  try {
+    const { id } = await deleteCampaign(campaign_id);
+    return NextResponse.json({ id }, { status: 200 });
+  } catch (error) {
+    log.error('Error deleting campaign:', error);
+    return NextResponse.json(
+      { success: false, message: 'Deleting Campaign data failed' },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/api/parties/promises/readiness/route.ts
+++ b/src/app/api/parties/promises/readiness/route.ts
@@ -1,79 +1,69 @@
-import { getPromisesReadiness } from "@/lib/database/parties/promises/promise-readiness/getPromisesReadiness";
-import { getuserPromisesReadiness } from "@/lib/database/parties/promises/promise-readiness/getUSerPromisesReadiness";
-import { setPromisesReadiness } from "@/lib/database/parties/promises/promise-readiness/setPromisesReadiness";
-import { updatePromisesReadiness } from "@/lib/database/parties/promises/promise-readiness/updatePromisesReadiness";
-import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { verifyJWT } from "@/lib/helpers/users/jwt";
-import { Logger } from "tslog";
+import { getPromisesReadiness } from '@/lib/database/parties/promises/promise-readiness/getPromisesReadiness';
+import { getuserPromisesReadiness } from '@/lib/database/parties/promises/promise-readiness/getUSerPromisesReadiness';
+import { setPromisesReadiness } from '@/lib/database/parties/promises/promise-readiness/setPromisesReadiness';
+import { updatePromisesReadiness } from '@/lib/database/parties/promises/promise-readiness/updatePromisesReadiness';
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { verifyJWT } from '@/lib/helpers/users/jwt';
+import { Logger } from 'tslog';
 
 const log = new Logger();
 
 export async function GET(request: NextRequest) {
- const { searchParams } = new URL(request.url);
- const campaign_id = Number(searchParams.get("campaign_id"));
+  const { searchParams } = new URL(request.url);
+  const campaign_id = Number(searchParams.get('campaign_id'));
 
- if (!campaign_id) {
- return NextResponse.json({ error: "Bad Request" }, { status: 400 });
- }
+  if (!campaign_id) {
+    return NextResponse.json({ error: 'Bad Request' }, { status: 400 });
+  }
 
- try {
- const readiness = await getPromisesReadiness(campaign_id);
- return NextResponse.json(readiness);
- } catch (error) {
- log.error("Error getting readiness data:", error);
- return NextResponse.json(
- {success: false, message: "Getting readiness data failed" },
- { status: 500 }
- );
- }
+  try {
+    const readiness = await getPromisesReadiness(campaign_id);
+    return NextResponse.json(readiness);
+  } catch (error) {
+    log.error('Error getting readiness data:', error);
+    return NextResponse.json(
+      { success: false, message: 'Getting readiness data failed' },
+      { status: 500 }
+    );
+  }
 }
 
 export async function POST(req: NextRequest) {
- // Extract user_id from verified JWT session, not from request body
- const session = (await cookies()).get("session")?.value;
- if (!session) {
- return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
- }
+  const session = (await cookies()).get('session')?.value;
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
 
- const payload = verifyJWT(session);
- if (!payload?.id) {
- return NextResponse.json({ error: "Invalid token" }, { status: 401 });
- }
+  const payload = verifyJWT(session);
+  if (!payload?.id) {
+    return NextResponse.json({ error: 'Invalid token' }, { status: 401 });
+  }
 
- const user_id = Number(payload.id);
+  const user_id = Number(payload.id);
 
- const { readiness_score, campaign_id } = await req.json();
+  const { readiness_score, campaign_id } = await req.json();
 
- if (!readiness_score || !campaign_id) {
- return NextResponse.json({ error: "Bad Request" }, { status: 400 });
- }
+  if (!readiness_score || !campaign_id) {
+    return NextResponse.json({ error: 'Bad Request' }, { status: 400 });
+  }
 
- try {
- // Check if user already submitted readiness
- const { readiness } = await getuserPromisesReadiness(campaign_id, user_id);
+  try {
+    const { readiness } = await getuserPromisesReadiness(campaign_id, user_id);
 
- if (readiness?.id) {
- const id = await updatePromisesReadiness(
- campaign_id,
- user_id,
- parseFloat(readiness_score)
- );
- return NextResponse.json(id, { status: 201 });
- }
+    if (readiness?.id) {
+      const id = await updatePromisesReadiness(campaign_id, user_id, parseFloat(readiness_score));
+      return NextResponse.json(id, { status: 201 });
+    }
 
- const id = await setPromisesReadiness(
- campaign_id,
- user_id,
- parseFloat(readiness_score)
- );
+    const id = await setPromisesReadiness(campaign_id, user_id, parseFloat(readiness_score));
 
- return NextResponse.json(id, { status: 201 });
- } catch (error) {
- log.error("Error saving readiness data:", error);
- return NextResponse.json(
- { success: false, message: "Saving readiness data failed" },
- { status: 500 }
- );
- }
+    return NextResponse.json(id, { status: 201 });
+  } catch (error) {
+    log.error('Error saving readiness data:', error);
+    return NextResponse.json(
+      { success: false, message: 'Saving readiness data failed' },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/api/parties/promises/readiness/route.ts
+++ b/src/app/api/parties/promises/readiness/route.ts
@@ -3,70 +3,77 @@ import { getuserPromisesReadiness } from "@/lib/database/parties/promises/promis
 import { setPromisesReadiness } from "@/lib/database/parties/promises/promise-readiness/setPromisesReadiness";
 import { updatePromisesReadiness } from "@/lib/database/parties/promises/promise-readiness/updatePromisesReadiness";
 import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { verifyJWT } from "@/lib/helpers/users/jwt";
 import { Logger } from "tslog";
 
 const log = new Logger();
 
 export async function GET(request: NextRequest) {
-  const { searchParams } = new URL(request.url);
-  const campaign_id = Number(searchParams.get("campaign_id"));
+ const { searchParams } = new URL(request.url);
+ const campaign_id = Number(searchParams.get("campaign_id"));
 
-  if (!campaign_id) {
-    return NextResponse.json({ error: "Bad Request" }, { status: 400 });
-  }
+ if (!campaign_id) {
+ return NextResponse.json({ error: "Bad Request" }, { status: 400 });
+ }
 
-  try {
-    const readiness = await getPromisesReadiness(campaign_id);
-    return NextResponse.json(readiness);
-  } catch (error) {
-    log.error("Error encoding data:", error);
-    return NextResponse.json(
-      {
-        success: false,
-        message: "Getting PRomises Readiness data failed",
-        error: String(error),
-      },
-      { status: 200 }
-    );
-  }
+ try {
+ const readiness = await getPromisesReadiness(campaign_id);
+ return NextResponse.json(readiness);
+ } catch (error) {
+ log.error("Error getting readiness data:", error);
+ return NextResponse.json(
+ {success: false, message: "Getting readiness data failed" },
+ { status: 500 }
+ );
+ }
 }
 
 export async function POST(req: NextRequest) {
-  const { readiness_score, user_id, campaign_id } = await req.json();
+ // Extract user_id from verified JWT session, not from request body
+ const session = (await cookies()).get("session")?.value;
+ if (!session) {
+ return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+ }
 
-  if (!readiness_score || !user_id || !campaign_id || !campaign_id) {
-    return NextResponse.json({ error: "Bad Request" }, { status: 400 });
-  }
+ const payload = verifyJWT(session);
+ if (!payload?.id) {
+ return NextResponse.json({ error: "Invalid token" }, { status: 401 });
+ }
 
-  try {
-    // Check if user already liked it
-    const { readiness } = await getuserPromisesReadiness(campaign_id, user_id);
+ const user_id = Number(payload.id);
 
-    if (readiness?.id) {
-      const id = await updatePromisesReadiness(
-        campaign_id,
-        user_id,
-        parseFloat(readiness_score)
-      );
-      return NextResponse.json(id, { status: 201 });
-    }
+ const { readiness_score, campaign_id } = await req.json();
 
-    const id = await setPromisesReadiness(
-      campaign_id,
-      user_id,
-      parseFloat(readiness_score)
-    );
+ if (!readiness_score || !campaign_id) {
+ return NextResponse.json({ error: "Bad Request" }, { status: 400 });
+ }
 
-    return NextResponse.json(id, { status: 201 });
-  } catch (error) {
-    log.error("Error saving readiness data:", error);
-    return NextResponse.json(
-      {
-        success: false,
-        message: "Saving readiness data failed",
-        error: String(error),
-      },
-      { status: 200 }
-    );
-  }
+ try {
+ // Check if user already submitted readiness
+ const { readiness } = await getuserPromisesReadiness(campaign_id, user_id);
+
+ if (readiness?.id) {
+ const id = await updatePromisesReadiness(
+ campaign_id,
+ user_id,
+ parseFloat(readiness_score)
+ );
+ return NextResponse.json(id, { status: 201 });
+ }
+
+ const id = await setPromisesReadiness(
+ campaign_id,
+ user_id,
+ parseFloat(readiness_score)
+ );
+
+ return NextResponse.json(id, { status: 201 });
+ } catch (error) {
+ log.error("Error saving readiness data:", error);
+ return NextResponse.json(
+ { success: false, message: "Saving readiness data failed" },
+ { status: 500 }
+ );
+ }
 }

--- a/src/app/api/parties/promises/route.ts
+++ b/src/app/api/parties/promises/route.ts
@@ -1,85 +1,80 @@
-import { deletePromise } from "@/lib/database/parties/promises/deletePromise";
-import { fetchPartyPromises } from "@/lib/database/parties/promises/getPartyPromises";
-import { fetchStructuredPartyPromises } from "@/lib/database/parties/promises/getStructuredPartyPromises";
-import { savePartyPromise } from "@/lib/database/parties/promises/savePartyPromise";
-import { NextRequest, NextResponse } from "next/server";
-import { isAuthorized } from "@/src/middleware/isAuthorized";
-import { Logger } from "tslog";
+import { deletePromise } from '@/lib/database/parties/promises/deletePromise';
+import { fetchPartyPromises } from '@/lib/database/parties/promises/getPartyPromises';
+import { fetchStructuredPartyPromises } from '@/lib/database/parties/promises/getStructuredPartyPromises';
+import { savePartyPromise } from '@/lib/database/parties/promises/savePartyPromise';
+import { NextRequest, NextResponse } from 'next/server';
+import { isAuthorized } from '@/src/middleware/isAuthorized';
+import { Logger } from 'tslog';
 
 const log = new Logger();
 
 export async function GET(request: NextRequest) {
- try {
- const { searchParams } = new URL(request.url);
- const party_id = Number(searchParams.get("party_id"));
- const campaign_id = Number(searchParams.get("campaign_id"));
- const structured = searchParams.get("structured");
+  try {
+    const { searchParams } = new URL(request.url);
+    const party_id = Number(searchParams.get('party_id'));
+    const campaign_id = Number(searchParams.get('campaign_id'));
+    const structured = searchParams.get('structured');
 
- if (!party_id || !campaign_id || isNaN(campaign_id) || isNaN(party_id)) {
- return NextResponse.json({ error: "Bad Request" }, { status: 400 });
- }
+    if (!party_id || !campaign_id || isNaN(campaign_id) || isNaN(party_id)) {
+      return NextResponse.json({ error: 'Bad Request' }, { status: 400 });
+    }
 
- const { promises } = structured
- ? await fetchStructuredPartyPromises(party_id, campaign_id)
- : await fetchPartyPromises(party_id, campaign_id);
+    const { promises } = structured
+      ? await fetchStructuredPartyPromises(party_id, campaign_id)
+      : await fetchPartyPromises(party_id, campaign_id);
 
- return NextResponse.json(promises);
- } catch (error) {
- log.error("Error fetching promises:", error);
- return NextResponse.json(
- { success: false, message: "Getting Promises data failed" },
- { status: 500 }
- );
- }
+    return NextResponse.json(promises);
+  } catch (error) {
+    log.error('Error fetching promises:', error);
+    return NextResponse.json(
+      { success: false, message: 'Getting Promises data failed' },
+      { status: 500 }
+    );
+  }
 }
 
 export async function POST(req: NextRequest) {
- if (!(await isAuthorized(req))) {
- return NextResponse.json({ error: "Forbidden" }, { status: 403 });
- }
+  if (!(await isAuthorized(req))) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
 
- const { promise, subject_id, campaign_id, party_id } = await req.json();
+  const { promise, subject_id, campaign_id, party_id } = await req.json();
 
- if (!promise || !subject_id || !campaign_id || !party_id) {
- return NextResponse.json({ error: "Bad Request" }, { status: 400 });
- }
+  if (!promise || !subject_id || !campaign_id || !party_id) {
+    return NextResponse.json({ error: 'Bad Request' }, { status: 400 });
+  }
 
- try {
- const { id } = await savePartyPromise(
- party_id,
- campaign_id,
- subject_id,
- promise
- );
- return NextResponse.json({ id }, { status: 201 });
- } catch (error) {
- log.error("Error saving promise:", error);
- return NextResponse.json(
- { success: false, message: "Saving Promise data failed" },
- { status: 500 }
- );
- }
+  try {
+    const { id } = await savePartyPromise(party_id, campaign_id, subject_id, promise);
+    return NextResponse.json({ id }, { status: 201 });
+  } catch (error) {
+    log.error('Error saving promise:', error);
+    return NextResponse.json(
+      { success: false, message: 'Saving Promise data failed' },
+      { status: 500 }
+    );
+  }
 }
 
 export async function DELETE(req: NextRequest) {
- if (!(await isAuthorized(req))) {
- return NextResponse.json({ error: "Forbidden" }, { status: 403 });
- }
+  if (!(await isAuthorized(req))) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
 
- const { promise_id } = await req.json();
+  const { promise_id } = await req.json();
 
- if (!promise_id) {
- return NextResponse.json({ error: "Bad Request" }, { status: 400 });
- }
+  if (!promise_id) {
+    return NextResponse.json({ error: 'Bad Request' }, { status: 400 });
+  }
 
- try {
- const { id } = await deletePromise(promise_id);
- return NextResponse.json({ id }, { status: 200 });
- } catch (error) {
- log.error("Error deleting promise:", error);
- return NextResponse.json(
- { success: false, message: "Deleting Promise data failed" },
- { status: 500 }
- );
- }
+  try {
+    const { id } = await deletePromise(promise_id);
+    return NextResponse.json({ id }, { status: 200 });
+  } catch (error) {
+    log.error('Error deleting promise:', error);
+    return NextResponse.json(
+      { success: false, message: 'Deleting Promise data failed' },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/api/parties/promises/route.ts
+++ b/src/app/api/parties/promises/route.ts
@@ -3,87 +3,83 @@ import { fetchPartyPromises } from "@/lib/database/parties/promises/getPartyProm
 import { fetchStructuredPartyPromises } from "@/lib/database/parties/promises/getStructuredPartyPromises";
 import { savePartyPromise } from "@/lib/database/parties/promises/savePartyPromise";
 import { NextRequest, NextResponse } from "next/server";
+import { isAuthorized } from "@/src/middleware/isAuthorized";
 import { Logger } from "tslog";
 
 const log = new Logger();
 
 export async function GET(request: NextRequest) {
-  try {
-    const { searchParams } = new URL(request.url); // Extract search params
-    const party_id = Number(searchParams.get("party_id"));
-    const campaign_id = Number(searchParams.get("campaign_id"));
-    const structured = searchParams.get("structured");
+ try {
+ const { searchParams } = new URL(request.url);
+ const party_id = Number(searchParams.get("party_id"));
+ const campaign_id = Number(searchParams.get("campaign_id"));
+ const structured = searchParams.get("structured");
 
-    if (!party_id || !campaign_id || isNaN(campaign_id) || isNaN(party_id)) {
-      return NextResponse.json({ error: "Bad Request" }, { status: 400 });
-    }
+ if (!party_id || !campaign_id || isNaN(campaign_id) || isNaN(party_id)) {
+ return NextResponse.json({ error: "Bad Request" }, { status: 400 });
+ }
 
-    const { promises } = structured
-      ? await fetchStructuredPartyPromises(party_id, campaign_id)
-      : await fetchPartyPromises(party_id, campaign_id);
+ const { promises } = structured
+ ? await fetchStructuredPartyPromises(party_id, campaign_id)
+ : await fetchPartyPromises(party_id, campaign_id);
 
-    return NextResponse.json(promises);
-  } catch (error) {
-    log.error("Error encoding data:", error);
-    return NextResponse.json(
-      {
-        success: false,
-        message: "Getting Parties data failed",
-        error: String(error),
-      },
-      { status: 200 }
-    );
-  }
+ return NextResponse.json(promises);
+ } catch (error) {
+ log.error("Error fetching promises:", error);
+ return NextResponse.json(
+ { success: false, message: "Getting Promises data failed" },
+ { status: 500 }
+ );
+ }
 }
 
 export async function POST(req: NextRequest) {
-  const { promise, subject_id, campaign_id, party_id } = await req.json();
+ if (!(await isAuthorized(req))) {
+ return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+ }
 
-  if (!promise || !subject_id || !campaign_id || !party_id) {
-    return NextResponse.json({ error: "Bad Request" }, { status: 400 });
-  }
+ const { promise, subject_id, campaign_id, party_id } = await req.json();
 
-  try {
-    const { id } = await savePartyPromise(
-      party_id,
-      campaign_id,
-      subject_id,
-      promise
-    );
-    return NextResponse.json({ id }, { status: 201 });
-  } catch (error) {
-    log.error("Error encoding data:", error);
-    return NextResponse.json(
-      {
-        success: false,
-        message: "Saving Parties data failed",
-        error: String(error),
-      },
-      { status: 200 }
-    );
-  }
+ if (!promise || !subject_id || !campaign_id || !party_id) {
+ return NextResponse.json({ error: "Bad Request" }, { status: 400 });
+ }
+
+ try {
+ const { id } = await savePartyPromise(
+ party_id,
+ campaign_id,
+ subject_id,
+ promise
+ );
+ return NextResponse.json({ id }, { status: 201 });
+ } catch (error) {
+ log.error("Error saving promise:", error);
+ return NextResponse.json(
+ { success: false, message: "Saving Promise data failed" },
+ { status: 500 }
+ );
+ }
 }
 
 export async function DELETE(req: NextRequest) {
-  const { promise_id } = await req.json();
+ if (!(await isAuthorized(req))) {
+ return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+ }
 
-  if (!promise_id) {
-    return NextResponse.json({ error: "Bad Request" }, { status: 400 });
-  }
+ const { promise_id } = await req.json();
 
-  try {
-    const { id } = await deletePromise(promise_id);
+ if (!promise_id) {
+ return NextResponse.json({ error: "Bad Request" }, { status: 400 });
+ }
 
-    return NextResponse.json({ id }, { status: 201 });
-  } catch (error) {
-    log.error("Error encoding data:", error);
-    return NextResponse.json(
-      {
-        success: false,
-        message: "Saving Parties data failed",
-        error: String(error),
-      },
-      { status: 200 }
-    );
-  }
+ try {
+ const { id } = await deletePromise(promise_id);
+ return NextResponse.json({ id }, { status: 200 });
+ } catch (error) {
+ log.error("Error deleting promise:", error);
+ return NextResponse.json(
+ { success: false, message: "Deleting Promise data failed" },
+ { status: 500 }
+ );
+ }
 }

--- a/src/app/api/parties/route.ts
+++ b/src/app/api/parties/route.ts
@@ -2,71 +2,66 @@ import { deleteParty } from "@/lib/database/parties/deleteParty";
 import { fetchAllParties } from "@/lib/database/parties/getAllParties";
 import { saveParty } from "@/lib/database/parties/saveParty";
 import { NextRequest, NextResponse } from "next/server";
+import { isAuthorized } from "@/src/middleware/isAuthorized";
 import { Logger } from "tslog";
 
 const log = new Logger();
 
 export async function GET() {
-  try {
-    const { parties } = await fetchAllParties();
-
-    return NextResponse.json(parties);
-  } catch (error) {
-    log.error("Error encoding data:", error);
-    return NextResponse.json(
-      {
-        success: false,
-        message: "Getting Parties data failed",
-        error: String(error),
-      },
-      { status: 200 }
-    );
-  }
+ try {
+ const { parties } = await fetchAllParties();
+ return NextResponse.json(parties);
+ } catch (error) {
+ log.error("Error fetching parties:", error);
+ return NextResponse.json(
+ { success: false, message: "Getting Parties data failed" },
+ { status: 500 }
+ );
+ }
 }
 
 export async function POST(req: NextRequest) {
-  const { name, logo_url } = await req.json();
+ if (!(await isAuthorized(req))) {
+ return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+ }
 
-  if (!name || !logo_url) {
-    return NextResponse.json({ error: "Bad Request" }, { status: 400 });
-  }
+ const { name, logo_url } = await req.json();
 
-  try {
-    const { id } = await saveParty(name, logo_url);
-    return NextResponse.json({ id }, { status: 201 });
-  } catch (error) {
-    log.error("Error encoding data:", error);
-    return NextResponse.json(
-      {
-        success: false,
-        message: "Saving Parties data failed",
-        error: String(error),
-      },
-      { status: 200 }
-    );
-  }
+ if (!name || !logo_url) {
+ return NextResponse.json({ error: "Bad Request" }, { status: 400 });
+ }
+
+ try {
+ const { id } = await saveParty(name, logo_url);
+ return NextResponse.json({ id }, { status: 201 });
+ } catch (error) {
+ log.error("Error saving party:", error);
+ return NextResponse.json(
+ { success: false, message: "Saving Party data failed" },
+ { status: 500 }
+ );
+ }
 }
 
 export async function DELETE(req: NextRequest) {
-  const { party_id } = await req.json();
+ if (!(await isAuthorized(req))) {
+ return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+ }
 
-  if (!party_id) {
-    return NextResponse.json({ error: "Bad Request" }, { status: 400 });
-  }
+ const { party_id } = await req.json();
 
-  try {
-    const { id } = await deleteParty(party_id);
+ if (!party_id) {
+ return NextResponse.json({ error: "Bad Request" }, { status: 400 });
+ }
 
-    return NextResponse.json({ id }, { status: 201 });
-  } catch (error) {
-    log.error("Error encoding data:", error);
-    return NextResponse.json(
-      {
-        success: false,
-        message: "Saving Parties data failed",
-        error: String(error),
-      },
-      { status: 200 }
-    );
-  }
+ try {
+ const { id } = await deleteParty(party_id);
+ return NextResponse.json({ id }, { status: 200 });
+ } catch (error) {
+ log.error("Error deleting party:", error);
+ return NextResponse.json(
+ { success: false, message: "Deleting Party data failed" },
+ { status: 500 }
+ );
+ }
 }

--- a/src/app/api/parties/route.ts
+++ b/src/app/api/parties/route.ts
@@ -1,67 +1,67 @@
-import { deleteParty } from "@/lib/database/parties/deleteParty";
-import { fetchAllParties } from "@/lib/database/parties/getAllParties";
-import { saveParty } from "@/lib/database/parties/saveParty";
-import { NextRequest, NextResponse } from "next/server";
-import { isAuthorized } from "@/src/middleware/isAuthorized";
-import { Logger } from "tslog";
+import { deleteParty } from '@/lib/database/parties/deleteParty';
+import { fetchAllParties } from '@/lib/database/parties/getAllParties';
+import { saveParty } from '@/lib/database/parties/saveParty';
+import { NextRequest, NextResponse } from 'next/server';
+import { isAuthorized } from '@/src/middleware/isAuthorized';
+import { Logger } from 'tslog';
 
 const log = new Logger();
 
 export async function GET() {
- try {
- const { parties } = await fetchAllParties();
- return NextResponse.json(parties);
- } catch (error) {
- log.error("Error fetching parties:", error);
- return NextResponse.json(
- { success: false, message: "Getting Parties data failed" },
- { status: 500 }
- );
- }
+  try {
+    const { parties } = await fetchAllParties();
+    return NextResponse.json(parties);
+  } catch (error) {
+    log.error('Error fetching parties:', error);
+    return NextResponse.json(
+      { success: false, message: 'Getting Parties data failed' },
+      { status: 500 }
+    );
+  }
 }
 
 export async function POST(req: NextRequest) {
- if (!(await isAuthorized(req))) {
- return NextResponse.json({ error: "Forbidden" }, { status: 403 });
- }
+  if (!(await isAuthorized(req))) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
 
- const { name, logo_url } = await req.json();
+  const { name, logo_url } = await req.json();
 
- if (!name || !logo_url) {
- return NextResponse.json({ error: "Bad Request" }, { status: 400 });
- }
+  if (!name || !logo_url) {
+    return NextResponse.json({ error: 'Bad Request' }, { status: 400 });
+  }
 
- try {
- const { id } = await saveParty(name, logo_url);
- return NextResponse.json({ id }, { status: 201 });
- } catch (error) {
- log.error("Error saving party:", error);
- return NextResponse.json(
- { success: false, message: "Saving Party data failed" },
- { status: 500 }
- );
- }
+  try {
+    const { id } = await saveParty(name, logo_url);
+    return NextResponse.json({ id }, { status: 201 });
+  } catch (error) {
+    log.error('Error saving party:', error);
+    return NextResponse.json(
+      { success: false, message: 'Saving Party data failed' },
+      { status: 500 }
+    );
+  }
 }
 
 export async function DELETE(req: NextRequest) {
- if (!(await isAuthorized(req))) {
- return NextResponse.json({ error: "Forbidden" }, { status: 403 });
- }
+  if (!(await isAuthorized(req))) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
 
- const { party_id } = await req.json();
+  const { party_id } = await req.json();
 
- if (!party_id) {
- return NextResponse.json({ error: "Bad Request" }, { status: 400 });
- }
+  if (!party_id) {
+    return NextResponse.json({ error: 'Bad Request' }, { status: 400 });
+  }
 
- try {
- const { id } = await deleteParty(party_id);
- return NextResponse.json({ id }, { status: 200 });
- } catch (error) {
- log.error("Error deleting party:", error);
- return NextResponse.json(
- { success: false, message: "Deleting Party data failed" },
- { status: 500 }
- );
- }
+  try {
+    const { id } = await deleteParty(party_id);
+    return NextResponse.json({ id }, { status: 200 });
+  } catch (error) {
+    log.error('Error deleting party:', error);
+    return NextResponse.json(
+      { success: false, message: 'Deleting Party data failed' },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/api/parties/subjects/route.ts
+++ b/src/app/api/parties/subjects/route.ts
@@ -2,71 +2,66 @@ import { deleteSubject } from "@/lib/database/parties/subjects/deleteSubject";
 import { fetchAllsubjects } from "@/lib/database/parties/subjects/getAllSubjects";
 import { saveSubject } from "@/lib/database/parties/subjects/saveSubject";
 import { NextRequest, NextResponse } from "next/server";
+import { isAuthorized } from "@/src/middleware/isAuthorized";
 import { Logger } from "tslog";
 
 const log = new Logger();
 
 export async function GET() {
-  try {
-    const { subjects } = await fetchAllsubjects();
-
-    return NextResponse.json(subjects);
-  } catch (error) {
-    log.error("Error encoding data:", error);
-    return NextResponse.json(
-      {
-        success: false,
-        message: "Getting Parties data failed",
-        error: String(error),
-      },
-      { status: 200 }
-    );
-  }
+ try {
+ const { subjects } = await fetchAllsubjects();
+ return NextResponse.json(subjects);
+ } catch (error) {
+ log.error("Error fetching subjects:", error);
+ return NextResponse.json(
+ { success: false, message: "Getting Subjects data failed" },
+ { status: 500 }
+ );
+ }
 }
 
 export async function POST(req: NextRequest) {
-  const { name, description } = await req.json();
+ if (!(await isAuthorized(req))) {
+ return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+ }
 
-  if (!name || !description) {
-    return NextResponse.json({ error: "Bad Request" }, { status: 400 });
-  }
+ const { name, description } = await req.json();
 
-  try {
-    const { id } = await saveSubject(name, description);
-    return NextResponse.json({ id }, { status: 201 });
-  } catch (error) {
-    log.error("Error encoding data:", error);
-    return NextResponse.json(
-      {
-        success: false,
-        message: "Saving Parties data failed",
-        error: String(error),
-      },
-      { status: 200 }
-    );
-  }
+ if (!name || !description) {
+ return NextResponse.json({ error: "Bad Request" }, { status: 400 });
+ }
+
+ try {
+ const { id } = await saveSubject(name, description);
+ return NextResponse.json({ id }, { status: 201 });
+ } catch (error) {
+ log.error("Error saving subject:", error);
+ return NextResponse.json(
+ { success: false, message: "Saving Subject data failed" },
+ { status: 500 }
+ );
+ }
 }
 
 export async function DELETE(req: NextRequest) {
-  const { subject_id } = await req.json();
+ if (!(await isAuthorized(req))) {
+ return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+ }
 
-  if (!subject_id) {
-    return NextResponse.json({ error: "Bad Request" }, { status: 400 });
-  }
+ const { subject_id } = await req.json();
 
-  try {
-    const { id } = await deleteSubject(subject_id);
+ if (!subject_id) {
+ return NextResponse.json({ error: "Bad Request" }, { status: 400 });
+ }
 
-    return NextResponse.json({ id }, { status: 201 });
-  } catch (error) {
-    log.error("Error encoding data:", error);
-    return NextResponse.json(
-      {
-        success: false,
-        message: "Saving Parties data failed",
-        error: String(error),
-      },
-      { status: 200 }
-    );
-  }
+ try {
+ const { id } = await deleteSubject(subject_id);
+ return NextResponse.json({ id }, { status: 200 });
+ } catch (error) {
+ log.error("Error deleting subject:", error);
+ return NextResponse.json(
+ { success: false, message: "Deleting Subject data failed" },
+ { status: 500 }
+ );
+ }
 }

--- a/src/app/api/parties/subjects/route.ts
+++ b/src/app/api/parties/subjects/route.ts
@@ -1,67 +1,67 @@
-import { deleteSubject } from "@/lib/database/parties/subjects/deleteSubject";
-import { fetchAllsubjects } from "@/lib/database/parties/subjects/getAllSubjects";
-import { saveSubject } from "@/lib/database/parties/subjects/saveSubject";
-import { NextRequest, NextResponse } from "next/server";
-import { isAuthorized } from "@/src/middleware/isAuthorized";
-import { Logger } from "tslog";
+import { deleteSubject } from '@/lib/database/parties/subjects/deleteSubject';
+import { fetchAllsubjects } from '@/lib/database/parties/subjects/getAllSubjects';
+import { saveSubject } from '@/lib/database/parties/subjects/saveSubject';
+import { NextRequest, NextResponse } from 'next/server';
+import { isAuthorized } from '@/src/middleware/isAuthorized';
+import { Logger } from 'tslog';
 
 const log = new Logger();
 
 export async function GET() {
- try {
- const { subjects } = await fetchAllsubjects();
- return NextResponse.json(subjects);
- } catch (error) {
- log.error("Error fetching subjects:", error);
- return NextResponse.json(
- { success: false, message: "Getting Subjects data failed" },
- { status: 500 }
- );
- }
+  try {
+    const { subjects } = await fetchAllsubjects();
+    return NextResponse.json(subjects);
+  } catch (error) {
+    log.error('Error fetching subjects:', error);
+    return NextResponse.json(
+      { success: false, message: 'Getting Subjects data failed' },
+      { status: 500 }
+    );
+  }
 }
 
 export async function POST(req: NextRequest) {
- if (!(await isAuthorized(req))) {
- return NextResponse.json({ error: "Forbidden" }, { status: 403 });
- }
+  if (!(await isAuthorized(req))) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
 
- const { name, description } = await req.json();
+  const { name, description } = await req.json();
 
- if (!name || !description) {
- return NextResponse.json({ error: "Bad Request" }, { status: 400 });
- }
+  if (!name || !description) {
+    return NextResponse.json({ error: 'Bad Request' }, { status: 400 });
+  }
 
- try {
- const { id } = await saveSubject(name, description);
- return NextResponse.json({ id }, { status: 201 });
- } catch (error) {
- log.error("Error saving subject:", error);
- return NextResponse.json(
- { success: false, message: "Saving Subject data failed" },
- { status: 500 }
- );
- }
+  try {
+    const { id } = await saveSubject(name, description);
+    return NextResponse.json({ id }, { status: 201 });
+  } catch (error) {
+    log.error('Error saving subject:', error);
+    return NextResponse.json(
+      { success: false, message: 'Saving Subject data failed' },
+      { status: 500 }
+    );
+  }
 }
 
 export async function DELETE(req: NextRequest) {
- if (!(await isAuthorized(req))) {
- return NextResponse.json({ error: "Forbidden" }, { status: 403 });
- }
+  if (!(await isAuthorized(req))) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
 
- const { subject_id } = await req.json();
+  const { subject_id } = await req.json();
 
- if (!subject_id) {
- return NextResponse.json({ error: "Bad Request" }, { status: 400 });
- }
+  if (!subject_id) {
+    return NextResponse.json({ error: 'Bad Request' }, { status: 400 });
+  }
 
- try {
- const { id } = await deleteSubject(subject_id);
- return NextResponse.json({ id }, { status: 200 });
- } catch (error) {
- log.error("Error deleting subject:", error);
- return NextResponse.json(
- { success: false, message: "Deleting Subject data failed" },
- { status: 500 }
- );
- }
+  try {
+    const { id } = await deleteSubject(subject_id);
+    return NextResponse.json({ id }, { status: 200 });
+  } catch (error) {
+    log.error('Error deleting subject:', error);
+    return NextResponse.json(
+      { success: false, message: 'Deleting Subject data failed' },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/api/users/delete-user/route.ts
+++ b/src/app/api/users/delete-user/route.ts
@@ -1,34 +1,33 @@
 // src/app/api/users/delete-user/route.ts
-import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { verifyJWT } from "@/lib/helpers/users/jwt";
-import { deleteUser } from "@/lib/database/users/users";
-import { Logger } from "tslog";
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { verifyJWT } from '@/lib/helpers/users/jwt';
+import { deleteUser } from '@/lib/database/users/users';
+import { Logger } from 'tslog';
 
 const log = new Logger();
 
 export async function DELETE() {
- try {
- const session = (await cookies()).get("session");
+  try {
+    const session = (await cookies()).get('session');
 
- if (!session?.value) {
- return NextResponse.json({ error: "No ha sido posible borrar el usuario." }, { status: 401 });
- }
+    if (!session?.value) {
+      return NextResponse.json({ error: 'No ha sido posible borrar el usuario.' }, { status: 401 });
+    }
 
- const currentUser = verifyJWT(session.value);
+    const currentUser = verifyJWT(session.value);
 
- if (!currentUser) {
- return NextResponse.json({ error: "No ha sido posible borrar el usuario." }, { status: 401 });
- }
+    if (!currentUser) {
+      return NextResponse.json({ error: 'No ha sido posible borrar el usuario.' }, { status: 401 });
+    }
 
- await deleteUser(currentUser.name);
+    await deleteUser(currentUser.name);
 
- // Clear session
- (await cookies()).delete("session");
+    (await cookies()).delete('session');
 
- return NextResponse.json({}, { status: 200 });
- } catch (error) {
- log.error("Error deleting user:", error);
- return NextResponse.json({ error: "No ha sido posible borrar el usuario." }, { status: 500 });
- }
+    return NextResponse.json({}, { status: 200 });
+  } catch (error) {
+    log.error('Error deleting user:', error);
+    return NextResponse.json({ error: 'No ha sido posible borrar el usuario.' }, { status: 500 });
+  }
 }

--- a/src/app/api/users/delete-user/route.ts
+++ b/src/app/api/users/delete-user/route.ts
@@ -7,28 +7,28 @@ import { Logger } from "tslog";
 
 const log = new Logger();
 
-export async function GET() {
-  try {
-    const session = (await cookies()).get("session");
+export async function DELETE() {
+ try {
+ const session = (await cookies()).get("session");
 
-    if (!session?.value) {
-      return NextResponse.json({ error: "No ha sido posible borrar el usuario." }, { status: 401 });
-    }
+ if (!session?.value) {
+ return NextResponse.json({ error: "No ha sido posible borrar el usuario." }, { status: 401 });
+ }
 
-    const currentUser = verifyJWT(session.value);
+ const currentUser = verifyJWT(session.value);
 
-    if (!currentUser) {
-      return NextResponse.json({ error: "No ha sido posible borrar el usuario." }, { status: 401 });
-    }
+ if (!currentUser) {
+ return NextResponse.json({ error: "No ha sido posible borrar el usuario." }, { status: 401 });
+ }
 
-    await deleteUser(currentUser.name);
+ await deleteUser(currentUser.name);
 
-    // Clear session
-    (await cookies()).delete("session");
+ // Clear session
+ (await cookies()).delete("session");
 
-    return NextResponse.json({}, { status: 200 });
-  } catch (error) {
-    log.error("Error deleting user:", error);
-    return NextResponse.json({ error: "No ha sido posible borrar el usuario." }, { status: 500 });
-  }
+ return NextResponse.json({}, { status: 200 });
+ } catch (error) {
+ log.error("Error deleting user:", error);
+ return NextResponse.json({ error: "No ha sido posible borrar el usuario." }, { status: 500 });
+ }
 }

--- a/src/components/Promises/PromisesView.tsx
+++ b/src/components/Promises/PromisesView.tsx
@@ -92,7 +92,7 @@ export const PromisesView = () => {
     if (!campaignChoice || !user.currentUser) return;
     sendPromiseReadiness({
       readiness_score: promiseReadiness,
-      user_id: user.currentUser.id,
+ // user_id is now extracted from JWT session server-side
       campaign_id: campaignChoice.id,
     });
   };

--- a/src/components/Promises/PromisesView.tsx
+++ b/src/components/Promises/PromisesView.tsx
@@ -92,7 +92,6 @@ export const PromisesView = () => {
     if (!campaignChoice || !user.currentUser) return;
     sendPromiseReadiness({
       readiness_score: promiseReadiness,
- // user_id is now extracted from JWT session server-side
       campaign_id: campaignChoice.id,
     });
   };


### PR DESCRIPTION
C-2: Add isAuthorized check to all CRUD API routes
- Protect POST/DELETE on parties, campaigns, subjects, promises
- GET endpoints remain public (read-only data)

C-3: Fix readiness API identity spoofing
- Extract user_id from verified JWT session instead of request body
- Remove user_id from client-side PromisesView request

C-4: Fix CSRF vulnerability on delete-user endpoint
- Change from GET to DELETE method (prevents img-tag CSRF)
- Update profile page client to use 'delete' method

C-5: Add JWT expiration and algorithm pinning (also H-5)
- Add expiresIn: 24h to jwt.sign
- Pin algorithms: ['HS256'] in jwt.verify
- Update JWT tests to match new signatures

Bonus fixes:
- M-2 (partial): Remove error detail leakage across all party routes
- M-3: Fix HTTP 200 for errors → proper 500 status codes