### PR TITLE
Add missing tests for middleware, parliament database functions, and API routes

### DIFF
--- a/lib/__tests__/database/spanishParliament/getAllProposals.test.ts
+++ b/lib/__tests__/database/spanishParliament/getAllProposals.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/database/likes/getTotalLikesAndDislikes', () => ({
+  fetchAllLikesAndDislikes: vi.fn(),
+}));
+
+vi.mock('tslog', () => ({
+  Logger: class {
+    error = vi.fn();
+  },
+}));
+
+const { mockRange, mockFrom } = vi.hoisted(() => {
+  const mockRange = vi.fn();
+  const mockOrder2 = vi.fn(() => ({ range: mockRange }));
+  const mockOrder1 = vi.fn(() => ({ order: mockOrder2 }));
+  const mockSelect = vi.fn(() => ({ order: mockOrder1 }));
+  const mockFrom = vi.fn(() => ({ select: mockSelect }));
+  return { mockRange, mockFrom };
+});
+
+vi.mock('@/lib/supabaseClient', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+import { fetchAllLikesAndDislikes } from '@/lib/database/likes/getTotalLikesAndDislikes';
+import { getAllProposals } from '@/lib/database/spanishParliament/getAllProposals';
+
+const mockFetch = vi.mocked(fetchAllLikesAndDislikes);
+
+describe('getAllProposals', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockResolvedValue({ result: { likes: 0, dislikes: 0, proposal_id: 1 } });
+  });
+
+  it('should return proposals and count on success', async () => {
+    const proposals = [{ id: 1, title: 'Proposal 1' }, { id: 2, title: 'Proposal 2' }];
+    mockRange.mockResolvedValue({ data: proposals, count: 2, error: null });
+
+    const result = await getAllProposals(1, 10);
+
+    expect(result.proposals).toHaveLength(2);
+    expect(result.count).toBe(2);
+  });
+
+  it('should attach likesAndDislikes to each proposal', async () => {
+    const proposals = [{ id: 5, title: 'Test' }];
+    mockRange.mockResolvedValue({ data: proposals, count: 1, error: null });
+    mockFetch.mockResolvedValue({ result: { likes: 3, dislikes: 1, proposal_id: 5 } });
+
+    const result = await getAllProposals(1, 10);
+
+    expect(result.proposals[0].likesAndDislikes).toEqual({ likes: 3, dislikes: 1, proposal_id: 5 });
+    expect(mockFetch).toHaveBeenCalledWith(5);
+  });
+
+  it('should calculate correct range for page 2', async () => {
+    mockRange.mockResolvedValue({ data: [], count: 0, error: null });
+
+    await getAllProposals(2, 5);
+
+    expect(mockRange).toHaveBeenCalledWith(5, 9);
+  });
+
+  it('should throw when supabase returns an error', async () => {
+    mockRange.mockResolvedValue({ data: null, count: null, error: new Error('DB error') });
+
+    await expect(getAllProposals(1, 10)).rejects.toThrow();
+  });
+});

--- a/lib/__tests__/database/spanishParliament/getAllProposalsByExpedient.test.ts
+++ b/lib/__tests__/database/spanishParliament/getAllProposalsByExpedient.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/database/likes/getTotalLikesAndDislikes', () => ({
+  fetchAllLikesAndDislikes: vi.fn(),
+}));
+
+vi.mock('tslog', () => ({
+  Logger: class {
+    error = vi.fn();
+  },
+}));
+
+const { mockRange, mockFrom } = vi.hoisted(() => {
+  const mockRange = vi.fn();
+  const mockOrder2 = vi.fn(() => ({ range: mockRange }));
+  const mockOrder1 = vi.fn(() => ({ order: mockOrder2 }));
+  const mockIlike = vi.fn(() => ({ order: mockOrder1 }));
+  const mockSelect = vi.fn(() => ({ ilike: mockIlike }));
+  const mockFrom = vi.fn(() => ({ select: mockSelect }));
+  return { mockRange, mockFrom };
+});
+
+vi.mock('@/lib/supabaseClient', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+import { fetchAllLikesAndDislikes } from '@/lib/database/likes/getTotalLikesAndDislikes';
+import { getAllProposalsByExpedient } from '@/lib/database/spanishParliament/getAllProposalsByExpedient';
+
+const mockFetch = vi.mocked(fetchAllLikesAndDislikes);
+
+describe('getAllProposalsByExpedient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockResolvedValue({ result: { likes: 0, dislikes: 0, proposal_id: 1 } });
+  });
+
+  it('should return matching proposals and count', async () => {
+    const proposals = [{ id: 1, expedient_text: '141/000001' }];
+    mockRange.mockResolvedValue({ data: proposals, count: 1, error: null });
+
+    const result = await getAllProposalsByExpedient('141', 1, 10);
+
+    expect(result.proposals).toHaveLength(1);
+    expect(result.count).toBe(1);
+  });
+
+  it('should attach likesAndDislikes to each proposal', async () => {
+    const proposals = [{ id: 7, expedient_text: 'some text' }];
+    mockRange.mockResolvedValue({ data: proposals, count: 1, error: null });
+    mockFetch.mockResolvedValue({ result: { likes: 2, dislikes: 0, proposal_id: 7 } });
+
+    const result = await getAllProposalsByExpedient('some', 1, 10);
+
+    expect(result.proposals[0].likesAndDislikes).toEqual({ likes: 2, dislikes: 0, proposal_id: 7 });
+  });
+
+  it('should throw when supabase returns an error', async () => {
+    mockRange.mockResolvedValue({ data: null, count: null, error: new Error('DB error') });
+
+    await expect(getAllProposalsByExpedient('text', 1, 10)).rejects.toThrow();
+  });
+
+  it('should use correct pagination range for page 3', async () => {
+    mockRange.mockResolvedValue({ data: [], count: 0, error: null });
+
+    await getAllProposalsByExpedient('text', 3, 5);
+
+    expect(mockRange).toHaveBeenCalledWith(10, 14);
+  });
+});

--- a/lib/__tests__/database/spanishParliament/getProposalById.test.ts
+++ b/lib/__tests__/database/spanishParliament/getProposalById.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('tslog', () => ({
+  Logger: class {
+    error = vi.fn();
+  },
+}));
+
+const { mockSingleProposal, mockEqPromises, mockFrom } = vi.hoisted(() => {
+  const mockSingleProposal = vi.fn();
+  const mockEqProposal = vi.fn(() => ({ single: mockSingleProposal }));
+  const mockSelectProposal = vi.fn(() => ({ eq: mockEqProposal }));
+
+  const mockEqPromises = vi.fn();
+  const mockSelectPromises = vi.fn(() => ({ eq: mockEqPromises }));
+
+  const mockFrom = vi.fn((table: string) => {
+    if (table === 'proposals') return { select: mockSelectProposal };
+    if (table === 'promise_status') return { select: mockSelectPromises };
+    return { select: vi.fn() };
+  });
+
+  return { mockSingleProposal, mockEqPromises, mockFrom };
+});
+
+vi.mock('@/lib/supabaseClient', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+import { getProposalById } from '@/lib/database/spanishParliament/getProposalById';
+
+describe('getProposalById', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEqPromises.mockResolvedValue({ data: [], error: null });
+  });
+
+  it('should return a proposal with relatedPromises on success', async () => {
+    const proposal = { id: 1, title: 'Test Proposal', votes_parties_json: null };
+    mockSingleProposal.mockResolvedValue({ data: proposal, error: null });
+    mockEqPromises.mockResolvedValue({ data: [{ promise_id: 10 }], error: null });
+
+    const result = await getProposalById(1);
+
+    expect(result?.id).toBe(1);
+    expect(result?.relatedPromises).toHaveLength(1);
+  });
+
+  it('should unwrap votes_parties_json.votes when present', async () => {
+    const votes = [{ party: 'PP', for: 10 }];
+    const proposal = { id: 2, votes_parties_json: { votes } };
+    mockSingleProposal.mockResolvedValue({ data: proposal, error: null });
+
+    const result = await getProposalById(2);
+
+    expect(result?.votes_parties_json).toEqual(votes);
+  });
+
+  it('should return undefined when supabase returns an error', async () => {
+    mockSingleProposal.mockResolvedValue({ data: null, error: new Error('Not found') });
+
+    const result = await getProposalById(999);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should include empty relatedPromises when promise_status query fails', async () => {
+    const proposal = { id: 3, votes_parties_json: null };
+    mockSingleProposal.mockResolvedValue({ data: proposal, error: null });
+    mockEqPromises.mockResolvedValue({ data: null, error: new Error('join error') });
+
+    const result = await getProposalById(3);
+
+    expect(result?.relatedPromises).toEqual([]);
+  });
+});

--- a/src/__tests__/app/api/spanish-proposals/proposals.test.ts
+++ b/src/__tests__/app/api/spanish-proposals/proposals.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/database/spanishParliament/getAllProposals', () => ({
+  getAllProposals: vi.fn(),
+}));
+
+vi.mock('tslog', () => ({
+  Logger: class {
+    error = vi.fn();
+  },
+}));
+
+import { getAllProposals } from '@/lib/database/spanishParliament/getAllProposals';
+import { GET } from '@/src/app/api/spanish-proposals/route';
+import { NextRequest } from 'next/server';
+
+const mockGetAllProposals = vi.mocked(getAllProposals);
+
+function makeRequest(params: Record<string, string> = {}) {
+  const url = new URL('http://localhost/api/spanish-proposals');
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new NextRequest(url.toString());
+}
+
+describe('GET /api/spanish-proposals', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return proposals with pagination info', async () => {
+    const proposals = [{ id: 1, title: 'P1' }, { id: 2, title: 'P2' }];
+    mockGetAllProposals.mockResolvedValue({ proposals, count: 2 });
+
+    const res = await GET(makeRequest({ page: '1', pageSize: '10' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.proposals).toHaveLength(2);
+    expect(body.pagination.totalCount).toBe(2);
+    expect(body.pagination.totalPages).toBe(1);
+  });
+
+  it('should use default page=1 and pageSize=10 when params are absent', async () => {
+    mockGetAllProposals.mockResolvedValue({ proposals: [], count: 0 });
+
+    await GET(makeRequest());
+
+    expect(mockGetAllProposals).toHaveBeenCalledWith(1, 10);
+  });
+
+  it('should return 400 for invalid page parameter', async () => {
+    const res = await GET(makeRequest({ page: '0', pageSize: '10' }));
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 400 for non-numeric page parameter', async () => {
+    const res = await GET(makeRequest({ page: 'abc' }));
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 500 when database throws', async () => {
+    mockGetAllProposals.mockRejectedValue(new Error('DB error'));
+
+    const res = await GET(makeRequest());
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/__tests__/app/api/spanish-proposals/search.test.ts
+++ b/src/__tests__/app/api/spanish-proposals/search.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/database/spanishParliament/getAllProposalsByExpedient', () => ({
+  getAllProposalsByExpedient: vi.fn(),
+}));
+
+vi.mock('tslog', () => ({
+  Logger: class {
+    error = vi.fn();
+  },
+}));
+
+import { getAllProposalsByExpedient } from '@/lib/database/spanishParliament/getAllProposalsByExpedient';
+import { GET } from '@/src/app/api/spanish-proposals/search/route';
+import { NextRequest } from 'next/server';
+
+const mockSearch = vi.mocked(getAllProposalsByExpedient);
+
+function makeRequest(params: Record<string, string> = {}) {
+  const url = new URL('http://localhost/api/spanish-proposals/search');
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new NextRequest(url.toString());
+}
+
+describe('GET /api/spanish-proposals/search', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return 400 when expedient_text is missing', async () => {
+    const res = await GET(makeRequest({ page: '1', pageSize: '10' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 400 when page is less than 1', async () => {
+    const res = await GET(makeRequest({ expedient_text: 'test', page: '0', pageSize: '10' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('should return proposals matching the search term', async () => {
+    const proposals = [{ id: 1, expedient_text: '141/000001' }];
+    mockSearch.mockResolvedValue({ proposals, count: 1 });
+
+    const res = await GET(makeRequest({ expedient_text: '141', page: '1', pageSize: '10' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.proposals).toHaveLength(1);
+    expect(body.pagination.totalCount).toBe(1);
+  });
+
+  it('should pass expedient_text and pagination to the database function', async () => {
+    mockSearch.mockResolvedValue({ proposals: [], count: 0 });
+
+    await GET(makeRequest({ expedient_text: 'sanidad', page: '2', pageSize: '5' }));
+
+    expect(mockSearch).toHaveBeenCalledWith('sanidad', 2, 5);
+  });
+
+  it('should return 500 when database throws', async () => {
+    mockSearch.mockRejectedValue(new Error('DB error'));
+
+    const res = await GET(makeRequest({ expedient_text: 'test', page: '1', pageSize: '10' }));
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/__tests__/app/api/users/current-user.test.ts
+++ b/src/__tests__/app/api/users/current-user.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(),
+}));
+
+vi.mock('@/lib/helpers/users/jwt', () => ({
+  verifyJWT: vi.fn(),
+}));
+
+vi.mock('@/lib/database/users/users', () => ({
+  findUserByName: vi.fn(),
+}));
+
+vi.mock('tslog', () => ({
+  Logger: class {
+    error = vi.fn();
+  },
+}));
+
+import { cookies } from 'next/headers';
+import { verifyJWT } from '@/lib/helpers/users/jwt';
+import { findUserByName } from '@/lib/database/users/users';
+import { GET } from '@/src/app/api/users/current-user/route';
+
+const mockCookies = vi.mocked(cookies);
+const mockVerifyJWT = vi.mocked(verifyJWT);
+const mockFindUserByName = vi.mocked(findUserByName);
+
+const mockDelete = vi.fn();
+
+function setupCookies(sessionValue?: string) {
+  mockCookies.mockResolvedValue({
+    get: vi.fn((key: string) => (key === 'session' && sessionValue ? { value: sessionValue } : undefined)),
+    delete: mockDelete,
+  } as never);
+}
+
+describe('GET /api/users/current-user', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return null currentUser when no session cookie', async () => {
+    setupCookies();
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.currentUser).toBeNull();
+  });
+
+  it('should return 401 and delete cookie when JWT is invalid', async () => {
+    setupCookies('invalid_token');
+    mockVerifyJWT.mockReturnValue(null);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.currentUser).toBeNull();
+    expect(mockDelete).toHaveBeenCalledWith('session');
+  });
+
+  it('should return 401 and delete cookie when user no longer exists in DB', async () => {
+    setupCookies('valid_token');
+    mockVerifyJWT.mockReturnValue({ id: '1', name: 'ghost', iat: 0, exp: 0 });
+    mockFindUserByName.mockResolvedValue(null);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.currentUser).toBeNull();
+    expect(mockDelete).toHaveBeenCalledWith('session');
+  });
+
+  it('should return currentUser with is_admin flag when session is valid', async () => {
+    setupCookies('valid_token');
+    mockVerifyJWT.mockReturnValue({ id: '1', name: 'admin', iat: 0, exp: 0 });
+    mockFindUserByName.mockResolvedValue({ id: 1, name: 'admin', is_admin: true } as never);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.currentUser.name).toBe('admin');
+    expect(body.currentUser.is_admin).toBe(true);
+  });
+});

--- a/src/__tests__/app/api/users/signin.test.ts
+++ b/src/__tests__/app/api/users/signin.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(),
+}));
+
+vi.mock('@/lib/database/users/users', () => ({
+  findUserByName: vi.fn(),
+}));
+
+vi.mock('@/lib/database/users/fingerprint', () => ({
+  calculateSimilarity: vi.fn(),
+  findFingerprintsForUser: vi.fn(),
+  findSimilarFingerprint: vi.fn(),
+  saveFingerprint: vi.fn(),
+}));
+
+vi.mock('@/lib/helpers/users/password', () => ({
+  Password: {
+    toHash: vi.fn(),
+    compare: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/helpers/users/jwt', () => ({
+  createJWT: vi.fn(),
+}));
+
+vi.mock('tslog', () => ({
+  Logger: class {
+    error = vi.fn();
+  },
+}));
+
+import { cookies } from 'next/headers';
+import { findUserByName } from '@/lib/database/users/users';
+import {
+  calculateSimilarity,
+  findFingerprintsForUser,
+  findSimilarFingerprint,
+} from '@/lib/database/users/fingerprint';
+import { Password } from '@/lib/helpers/users/password';
+import { createJWT } from '@/lib/helpers/users/jwt';
+import { POST } from '@/src/app/api/users/signin/route';
+import { NextRequest } from 'next/server';
+
+const mockCookies = vi.mocked(cookies);
+const mockFindUserByName = vi.mocked(findUserByName);
+const mockPasswordCompare = vi.mocked(Password.compare);
+const mockFindFingerprintsForUser = vi.mocked(findFingerprintsForUser);
+const mockCalculateSimilarity = vi.mocked(calculateSimilarity);
+const mockFindSimilarFingerprint = vi.mocked(findSimilarFingerprint);
+const mockCreateJWT = vi.mocked(createJWT);
+
+const existingUser = { id: 1, name: 'testuser', password: 'hashed', is_admin: false };
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost/api/users/signin', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('POST /api/users/signin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCookies.mockResolvedValue({ set: vi.fn() } as never);
+    mockFindUserByName.mockResolvedValue(existingUser as never);
+    mockPasswordCompare.mockResolvedValue(true);
+    mockFindFingerprintsForUser.mockResolvedValue([{ device_hash: 'known_fp' }] as never);
+    mockCalculateSimilarity.mockResolvedValue(1);
+    mockCreateJWT.mockReturnValue('jwt_token');
+  });
+
+  it('should return 400 when name is invalid', async () => {
+    const res = await POST(makeRequest({ name: 'ab', password: 'password123', fingerprint: 'fp' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 401 when user does not exist', async () => {
+    mockFindUserByName.mockResolvedValue(null);
+
+    const res = await POST(makeRequest({ name: 'unknown', password: 'password123', fingerprint: 'fp' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('should return 401 when password does not match', async () => {
+    mockPasswordCompare.mockResolvedValue(false);
+
+    const res = await POST(makeRequest({ name: 'testuser', password: 'wrong', fingerprint: 'fp' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('should return 401 when fingerprint belongs to a different user', async () => {
+    mockCalculateSimilarity.mockResolvedValue(0);
+    mockFindSimilarFingerprint.mockResolvedValue({ id: 99 } as never);
+
+    const res = await POST(makeRequest({ name: 'testuser', password: 'password123', fingerprint: 'unknown_fp' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('should return 200 with user data on successful signin', async () => {
+    const res = await POST(makeRequest({ name: 'testuser', password: 'password123', fingerprint: 'known_fp' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.name).toBe('testuser');
+    expect(mockCreateJWT).toHaveBeenCalledOnce();
+  });
+});

--- a/src/__tests__/app/api/users/signup.test.ts
+++ b/src/__tests__/app/api/users/signup.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(),
+}));
+
+vi.mock('@/lib/database/users/users', () => ({
+  findUserByName: vi.fn(),
+  saveUser: vi.fn(),
+  deleteUser: vi.fn(),
+}));
+
+vi.mock('@/lib/database/users/fingerprint', () => ({
+  findSimilarFingerprint: vi.fn(),
+  saveFingerprint: vi.fn(),
+}));
+
+vi.mock('@/lib/helpers/users/password', () => ({
+  Password: {
+    toHash: vi.fn(),
+    compare: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/helpers/users/jwt', () => ({
+  createJWT: vi.fn(),
+}));
+
+vi.mock('tslog', () => ({
+  Logger: class {
+    error = vi.fn();
+  },
+}));
+
+import { cookies } from 'next/headers';
+import { findUserByName, saveUser } from '@/lib/database/users/users';
+import { findSimilarFingerprint, saveFingerprint } from '@/lib/database/users/fingerprint';
+import { Password } from '@/lib/helpers/users/password';
+import { createJWT } from '@/lib/helpers/users/jwt';
+import { POST } from '@/src/app/api/users/signup/route';
+import { NextRequest } from 'next/server';
+
+const mockCookies = vi.mocked(cookies);
+const mockFindUserByName = vi.mocked(findUserByName);
+const mockSaveUser = vi.mocked(saveUser);
+const mockFindSimilarFingerprint = vi.mocked(findSimilarFingerprint);
+const mockSaveFingerprint = vi.mocked(saveFingerprint);
+const mockPasswordHash = vi.mocked(Password.toHash);
+const mockCreateJWT = vi.mocked(createJWT);
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost/api/users/signup', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('POST /api/users/signup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCookies.mockResolvedValue({ set: vi.fn() } as never);
+    mockFindUserByName.mockResolvedValue(null);
+    mockFindSimilarFingerprint.mockResolvedValue(null);
+    mockPasswordHash.mockResolvedValue('hashed_pw');
+    mockSaveUser.mockResolvedValue({ id: 1, name: 'newuser' } as never);
+    mockSaveFingerprint.mockResolvedValue(undefined);
+    mockCreateJWT.mockReturnValue('jwt_token');
+  });
+
+  it('should return 400 when name is too short', async () => {
+    const res = await POST(makeRequest({ name: 'ab', password: 'password123', fingerprint: 'fp' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 400 when password is too short', async () => {
+    const res = await POST(makeRequest({ name: 'validuser', password: 'short', fingerprint: 'fp' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 400 when name contains invalid characters', async () => {
+    const res = await POST(makeRequest({ name: 'user name!', password: 'password123', fingerprint: 'fp' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 401 when username is already taken', async () => {
+    mockFindUserByName.mockResolvedValue({ id: 1, name: 'existinguser' } as never);
+
+    const res = await POST(makeRequest({ name: 'existinguser', password: 'password123', fingerprint: 'fp' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('should return 401 when fingerprint is already linked to another user', async () => {
+    mockFindSimilarFingerprint.mockResolvedValue({ id: 1 } as never);
+
+    const res = await POST(makeRequest({ name: 'newuser', password: 'password123', fingerprint: 'fp' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('should create user and return 201 on successful signup', async () => {
+    const res = await POST(makeRequest({ name: 'newuser', password: 'password123', fingerprint: 'fp' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.name).toBe('newuser');
+    expect(mockSaveUser).toHaveBeenCalledOnce();
+    expect(mockSaveFingerprint).toHaveBeenCalledOnce();
+    expect(mockCreateJWT).toHaveBeenCalledOnce();
+  });
+});

--- a/src/__tests__/middleware/isAuthorized.test.ts
+++ b/src/__tests__/middleware/isAuthorized.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(),
+}));
+
+vi.mock('@/lib/helpers/users/jwt', () => ({
+  verifyJWT: vi.fn(),
+}));
+
+vi.mock('@/lib/database/users/users', () => ({
+  findUserByName: vi.fn(),
+}));
+
+vi.mock('tslog', () => ({
+  Logger: class {
+    error = vi.fn();
+  },
+}));
+
+import { cookies } from 'next/headers';
+import { verifyJWT } from '@/lib/helpers/users/jwt';
+import { findUserByName } from '@/lib/database/users/users';
+import { isAuthorized } from '@/src/middleware/isAuthorized';
+import { NextRequest } from 'next/server';
+
+const mockCookies = vi.mocked(cookies);
+const mockVerifyJWT = vi.mocked(verifyJWT);
+const mockFindUserByName = vi.mocked(findUserByName);
+
+function makeRequest(headers: Record<string, string> = {}) {
+  return new NextRequest('http://localhost/api/test', { headers });
+}
+
+describe('isAuthorized', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    mockCookies.mockResolvedValue({ get: vi.fn(() => undefined) } as never);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should return true when authorization header matches CRON_SECRET', async () => {
+    process.env.CRON_SECRET = 'secret123';
+    const req = makeRequest({ authorization: 'Bearer secret123' });
+
+    expect(await isAuthorized(req)).toBe(true);
+  });
+
+  it('should not short-circuit on CRON_SECRET when header does not match', async () => {
+    process.env.CRON_SECRET = 'secret123';
+    mockCookies.mockResolvedValue({ get: vi.fn(() => undefined) } as never);
+    const req = makeRequest({ authorization: 'Bearer wrong' });
+
+    expect(await isAuthorized(req)).toBe(false);
+  });
+
+  it('should return false when there is no session cookie', async () => {
+    delete process.env.CRON_SECRET;
+    mockCookies.mockResolvedValue({ get: vi.fn(() => undefined) } as never);
+    const req = makeRequest();
+
+    expect(await isAuthorized(req)).toBe(false);
+  });
+
+  it('should return false when JWT is invalid', async () => {
+    delete process.env.CRON_SECRET;
+    mockCookies.mockResolvedValue({ get: vi.fn(() => ({ value: 'bad_token' })) } as never);
+    mockVerifyJWT.mockReturnValue(null);
+    const req = makeRequest();
+
+    expect(await isAuthorized(req)).toBe(false);
+  });
+
+  it('should return false when user is not admin', async () => {
+    delete process.env.CRON_SECRET;
+    mockCookies.mockResolvedValue({ get: vi.fn(() => ({ value: 'valid_token' })) } as never);
+    mockVerifyJWT.mockReturnValue({ id: '1', name: 'user', iat: 0, exp: 0 });
+    mockFindUserByName.mockResolvedValue({ id: 1, name: 'user', is_admin: false } as never);
+    const req = makeRequest();
+
+    expect(await isAuthorized(req)).toBe(false);
+  });
+
+  it('should return true when session cookie belongs to an admin user', async () => {
+    delete process.env.CRON_SECRET;
+    mockCookies.mockResolvedValue({ get: vi.fn(() => ({ value: 'valid_token' })) } as never);
+    mockVerifyJWT.mockReturnValue({ id: '1', name: 'admin', iat: 0, exp: 0 });
+    mockFindUserByName.mockResolvedValue({ id: 1, name: 'admin', is_admin: true } as never);
+    const req = makeRequest();
+
+    expect(await isAuthorized(req)).toBe(true);
+  });
+});

--- a/src/__tests__/middleware/requireAuth.test.ts
+++ b/src/__tests__/middleware/requireAuth.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(),
+}));
+
+vi.mock('@/lib/helpers/users/jwt', () => ({
+  verifyJWT: vi.fn(),
+}));
+
+import { cookies } from 'next/headers';
+import { verifyJWT } from '@/lib/helpers/users/jwt';
+import { requireAuth } from '@/src/middleware/requireAuth';
+import { NextResponse } from 'next/server';
+
+const mockCookies = vi.mocked(cookies);
+const mockVerifyJWT = vi.mocked(verifyJWT);
+
+describe('requireAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return 401 response when no session cookie exists', async () => {
+    mockCookies.mockResolvedValue({ get: vi.fn(() => undefined) } as never);
+
+    const result = await requireAuth();
+
+    expect(result).toBeInstanceOf(NextResponse);
+    const json = await (result as NextResponse).json();
+    expect(json.error).toBe('Unauthorized');
+    expect((result as NextResponse).status).toBe(401);
+  });
+
+  it('should return 401 response when JWT payload has no id', async () => {
+    mockCookies.mockResolvedValue({ get: vi.fn(() => ({ value: 'bad_token' })) } as never);
+    mockVerifyJWT.mockReturnValue(null);
+
+    const result = await requireAuth();
+
+    expect(result).toBeInstanceOf(NextResponse);
+    const json = await (result as NextResponse).json();
+    expect(json.error).toBe('Invalid or expired token');
+  });
+
+  it('should return user object with numeric user_id when token is valid', async () => {
+    mockCookies.mockResolvedValue({ get: vi.fn(() => ({ value: 'valid_token' })) } as never);
+    mockVerifyJWT.mockReturnValue({ id: '42', name: 'testuser', iat: 0, exp: 0 });
+
+    const result = await requireAuth();
+
+    expect(result).not.toBeInstanceOf(NextResponse);
+    const { user } = result as { user: { user_id: number; name: string } };
+    expect(user.user_id).toBe(42);
+    expect(user.name).toBe('testuser');
+  });
+
+  it('should not call verifyJWT when session cookie is missing', async () => {
+    mockCookies.mockResolvedValue({ get: vi.fn(() => undefined) } as never);
+
+    await requireAuth();
+
+    expect(mockVerifyJWT).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Tests cover: isAuthorized/requireAuth middleware, getAllProposals/getProposalById/getAllProposalsByExpedient database functions, and API routes for proposals listing, search, current-user, signup and signin.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YJrsmPVB42Y6ofmFpijUjK